### PR TITLE
Fix vbox searchpaths on FreeBSD

### DIFF
--- a/lib/virtualbox/ext/platform.rb
+++ b/lib/virtualbox/ext/platform.rb
@@ -19,6 +19,10 @@ module VirtualBox
         platform.include?("solaris")
       end
 
+      def freebsd?
+        platform.include?("freebsd")
+      end
+
       def jruby?
         RbConfig::CONFIG["ruby_install_name"] == "jruby"
       end

--- a/lib/virtualbox/lib.rb
+++ b/lib/virtualbox/lib.rb
@@ -62,6 +62,8 @@ module VirtualBox
                           "/usr/lib64/virtualbox/VBoxXPCOMC.so"]
           elsif Platform.solaris?
             @@lib_path = ["/opt/VirtualBox/amd64/VBoxXPCOMC.so", "/opt/VirtualBox/i386/VBoxXPCOMC.so"]
+          elsif Platform.freebsd?
+            @@lib_path = ["/usr/local/lib/virtualbox/VBoxXPCOMC.so"]
           elsif Platform.windows?
             @@lib_path = "Unknown"
           else


### PR DESCRIPTION
This patch simple adds the appropriate searchpath for the vbox shared object to fix the "Virtualbox not found" error on FreeBSD.
