### PR TITLE
Out Arrays should be treated as pointers to sizeof(pointer), not pointers to sizeof(type)

### DIFF
--- a/lib/virtualbox/com/implementer/ffi.rb
+++ b/lib/virtualbox/com/implementer/ffi.rb
@@ -151,7 +151,7 @@ module VirtualBox
               # For arrays we need two pointers: one for size, and one for the
               # actual array
               results << pointer_for_type(T_UINT32)
-              results << pointer_for_type(item[1][0])
+              results << pointer_for_type(:pointer)
             else
               results << pointer_for_type(item[1])
             end

--- a/test/virtualbox/com/implementer/ffi_test.rb
+++ b/test/virtualbox/com/implementer/ffi_test.rb
@@ -168,11 +168,11 @@ class COMImplementerFFITest < Test::Unit::TestCase
       end
 
       should "replace out array types with two parameters" do
-        @counter_pointer = mock("count_pointer")
+        @count_pointer = mock("count_pointer")
         @pointer = mock("pointer")
 
         @instance.expects(:pointer_for_type).with(VirtualBox::COM::T_UINT32).returns(@count_pointer)
-        @instance.expects(:pointer_for_type).with(:foo).returns(@pointer)
+        @instance.expects(:pointer_for_type).with(:pointer).returns(@pointer)
         assert_equal [@count_pointer, @pointer], @instance.spec_to_args([[:out, [:foo]]])
       end
     end


### PR DESCRIPTION
when constructing pointers for out arrays, a pointer of sizeof(void *) should be created, not of the size of the type.

When trying to read arrays of int32, ruby (64-bit on OSX) crashes because it tries to read an 8-byte pointer from a 4-byte value.
