### PR TITLE
Fix issue #37

### DIFF
--- a/lib/virtualbox/com/mscom_interface.rb
+++ b/lib/virtualbox/com/mscom_interface.rb
@@ -6,7 +6,6 @@ module VirtualBox
       # initialized, all other parts of the API can be accessed via these
       # instances.
       attr_reader :virtualbox
-      attr_reader :session
 
       def initialize
         super
@@ -26,8 +25,6 @@ module VirtualBox
         COM::Util.set_interface_version(version)
 
         @virtualbox = COM::Util.versioned_interface(:VirtualBox).new(Implementer::MSCOM, self, WIN32OLE.new("VirtualBox.VirtualBox"))
-        @session = COM::Util.versioned_interface(:Session).new(Implementer::MSCOM, self, WIN32OLE.new("VirtualBox.Session"))
-
         vb_version = @virtualbox.version
 
         # Check if they match or not.
@@ -38,6 +35,10 @@ module VirtualBox
         end
 
         true
+      end
+
+      def session
+        @session ||= COM::Util.versioned_interface(:Session).new(Implementer::MSCOM, self, WIN32OLE.new("VirtualBox.Session"))
       end
     end
   end

--- a/lib/virtualbox/lib.rb
+++ b/lib/virtualbox/lib.rb
@@ -83,7 +83,10 @@ module VirtualBox
       end
 
       @virtualbox = @interface.virtualbox
-      @session = @interface.session
+    end
+    
+    def session
+      @interface.session
     end
   end
 end


### PR DESCRIPTION
Well it actually not fix problem with win32ole and virtualbox, but now its report error correctly - it is not a problem with version detection, but problem with virtualbox COM interface

Now i get following error

```
mscom.rb:61:in `method_missing': (in OLE method `ImportMachines': ) (WIN32OLERuntimeError)
    OLE error code:0 in <Unknown>
      <No Description>
    HRESULT error code:0x80020005
```

Maybe connected to [#420](https://github.com/mitchellh/vagrant/issues/420)
